### PR TITLE
consolidate configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /generator/billing.data
 /internal/test-data/email.data
 README_PROJECT.md
-
+.idea

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -2,13 +2,28 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+
 	"sb-diplom-v2/internal/app"
+	"sb-diplom-v2/pkg/cfg"
 )
 
-var port = flag.Int("p", 8282, "server port")
-
-// main -.
 func main() {
+	var configFilePath string
+	flag.StringVar(&configFilePath, "config", "config/config.json", "cofig. file path")
 	flag.Parse()
-	app.Run(*port)
+
+	if configFilePath == "" {
+		fmt.Println("config. file path is empty")
+		os.Exit(1)
+	}
+
+	cfg, err := cfg.Init(configFilePath)
+	if err != nil {
+		fmt.Println("config. file path is empty")
+		os.Exit(1)
+	}
+
+	app.Run(cfg)
 }

--- a/config/config.json
+++ b/config/config.json
@@ -12,5 +12,8 @@
     "mms": "/mms",
     "support": "/support",
     "incident": "/accendent"
+  },
+  "http_server": {
+    "port": 8383
   }
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,23 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-co-op/gocron"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	cfg "sb-diplom-v2/internal"
-	"sb-diplom-v2/internal/logger"
-	_ "sb-diplom-v2/internal/logger"
-	"sb-diplom-v2/pkg"
 	"syscall"
 	"time"
+
+	cfg "sb-diplom-v2/internal"
+	"sb-diplom-v2/internal/logger"
+	"sb-diplom-v2/pkg"
+	cfg2 "sb-diplom-v2/pkg/cfg"
+
+	"github.com/go-co-op/gocron"
 )
 
 // Run presents the server logic
-func Run(port int) {
-
+func Run(cfgRoot *cfg2.Root) {
 	var cfg_ cfg.Config
 	var resultT cfg.StatusResult
 	var service = "skillbox diploma"
@@ -30,7 +31,7 @@ func Run(port int) {
 			logger.Logger.Warnf("Panic recovered after error: %v", err)
 		}
 	}()
-	start := fmt.Sprintf(":%d", port)
+	start := fmt.Sprintf(":%d", cfgRoot.HTTPServer.Port)
 	data, err := ioutil.ReadFile("config/config.json")
 	if err != nil {
 		log.Fatal(err.Error())
@@ -71,7 +72,7 @@ func Run(port int) {
 			logger.Logger.Fatalf("listen error %v\n", err)
 		}
 	}()
-	logger.Logger.Printf("%s starting on %d", service, port)
+	logger.Logger.Printf("%s starting on %d", service, cfgRoot.HTTPServer.Port)
 	<-stop
 
 	logger.Logger.Printf("%s shutting down ...", service)

--- a/pkg/cfg/http_server.go
+++ b/pkg/cfg/http_server.go
@@ -1,0 +1,23 @@
+package cfg
+
+import "fmt"
+
+type httpServer struct {
+	Port uint `json:"port"`
+}
+
+func (h *httpServer) initiate() error {
+	return h.validate()
+}
+
+func (h *httpServer) validate() error {
+	if h.Port == 0 {
+		return fmt.Errorf("port is empty")
+	}
+
+	if h.Port > 65535 {
+		return fmt.Errorf("invalid port")
+	}
+
+	return nil
+}

--- a/pkg/cfg/main.go
+++ b/pkg/cfg/main.go
@@ -1,0 +1,25 @@
+package cfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func Init(filePath string) (*Root, error) {
+	f, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %v", err)
+	}
+
+	var root Root
+	if err := json.Unmarshal(f, &root); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+
+	if err := root.initiate(); err != nil {
+		return nil, err
+	}
+
+	return &root, nil
+}

--- a/pkg/cfg/root.go
+++ b/pkg/cfg/root.go
@@ -1,0 +1,15 @@
+package cfg
+
+import "fmt"
+
+type Root struct {
+	HTTPServer httpServer `json:"http_server"`
+}
+
+func (r *Root) initiate() error {
+	if err := r.HTTPServer.initiate(); err != nil {
+		return fmt.Errorf("http_server: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Описание конфигурации в одном месте. Важно запускать программу с проверенной конфигурацией, чтоб не делать доп. проверок во время выполнения.
Сделал только для http server. Можете попробовать добавить остальные структуры (csv, httpreq). 
Для структур Root и HTTPServer добавил два метода: initiate, validate (только для HTTPServer). validate-метод запускает валидацию: проверям, что номер порта не пустой и указан правильно. initiate-метод нужен для определения дефолтных второстепенных настроек, если они не указыны явно (в моем примере этого нет, но позднее его можно будет заиспользовать).

Следующим шагом нужно:

1. добавить остальные структуры в Root.
2. передавать конфигурацию с генератор.